### PR TITLE
Error logging

### DIFF
--- a/app/agent/agent.py
+++ b/app/agent/agent.py
@@ -1,5 +1,5 @@
 ## Imports
-import socket,json,struct,docker,os,sys,datetime
+import socket,json,struct,docker,os,sys,datetime,logging
 
 ## Functions
 def log(tuple):
@@ -60,13 +60,13 @@ def startAgent():
                 sndPayload = sndPayload.encode()
                 socketSnd(clientsocket, sndPayload)
                 # log(('INFO','Sending',sndPayload))
-            except:
-                log(('ERR','Agent exited abnormally'))
+            except Exception:
+                logging.exception('Agent exited abnormally')
                 sys.exit(1)
             finally:
                 clientsocket.close()
     except:
-        log(('ERR','Agent failed to start or exited abnormally'))
+        logging.exception('Agent failed to start or exited abnormally')
 def containerStatCollection(refresh=False):
     ''' Create dict of container stat generator objects '''
     containers = dkrClient.df()['Containers']

--- a/app/agent/agent.py
+++ b/app/agent/agent.py
@@ -65,7 +65,7 @@ def startAgent():
                 sys.exit(1)
             finally:
                 clientsocket.close()
-    except:
+    except Exception:
         logging.exception('Agent failed to start or exited abnormally')
 def containerStatCollection(refresh=False):
     ''' Create dict of container stat generator objects '''


### PR DESCRIPTION
Changed the exception handling blocks to output trace in case of an error so we can potentially debug what has caused it rather than failing without giving a reason.

Also changed the exception block to only catch base exceptions i.e not system exit, we don't want to catch these exceptions without a re-raise by default. It's "safe" here because we do a system.exit after, but if that was removed it wouldn't be great.